### PR TITLE
Fix handling of '+' sign in sinfo output.

### DIFF
--- a/src/SLURMInfoUtils/SInfoHandler.py
+++ b/src/SLURMInfoUtils/SInfoHandler.py
@@ -116,7 +116,7 @@ class PartitionInfoHandler(Thread):
                         self.qtable[queue].slotsPerJob = maxNodes * maxCPUNode
                         
                     else:
-                        tmpl = qTuple[8].split(':')
+                        tmpl = [ i.translate(None, '+') for i in qTuple[8].split(':') ]                        
                         socketNum = int(tmpl[0])
                         coreNum = int(tmpl[1])
                         thrNum = int(tmpl[2])


### PR DESCRIPTION
In some cases, namely when a partition contains nodes with different core counts, it is possible for sinfo to produce output like this:

```
$ sinfo -h -o %z
2+:6+:1

```
the plus sign indicates, that the partition contains nodes with 2 or more sockets etc. Parser returned an error while trying to interpret '2+' as integer. It seems safe just to ignore the plus sign.

The problem was diagnosed and fixed by @jacentyb